### PR TITLE
add variable lookups

### DIFF
--- a/infra/tf-app/main.tf
+++ b/infra/tf-app/main.tf
@@ -43,7 +43,7 @@ data "terraform_remote_state" "elasticache" {
   backend = "s3"
   config = {
     region = var.aws_region
-    # TODO: exoport to var
+    # TODO: export to var
     bucket = "click-count-tfstate"
     key    = "env:/${var.env}/db/terraform.tfstate"
   }
@@ -185,21 +185,18 @@ resource "aws_elastic_beanstalk_environment" "click_count" {
     namespace = "aws:autoscaling:asg"
     name      = "Availability Zones"
     value     = var.asg_availability_zones
-    resource  = ""
   }
 
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "MinSize"
     value     = var.asg_min_size
-    resource  = ""
   }
 
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "MaxSize"
     value     = var.asg_max_size
-    resource  = ""
   }
 
   tags = {

--- a/infra/tf-db/main.tf
+++ b/infra/tf-db/main.tf
@@ -75,27 +75,17 @@ data "aws_security_group" "sg-allow-redis" {
   }
 }
 
-# FIXME
-# data "aws_security_group" "default" {
-
-#   filter {
-#     name   = "tag:Name"
-#     values = ["default"]
-#   }
-# }
-
-
 resource "aws_elasticache_replication_group" "click_count" {
-  replication_group_id          = "${var.project_name}-${var.stack}-${lookup(var.environment_name, var.env)}"
+  replication_group_id          = "${var.project_name}-${var.stack}-${var.env}"
   replication_group_description = "redis - click-count"
-  node_type                     = "cache.t2.micro"
+  node_type                     = lookup(var.node_types, var.env)
   port                          = 6379
-  parameter_group_name          = "default.redis6.x"
+  parameter_group_name          = lookup(var.parameter_group_names, var.env)
   security_group_ids            = [data.aws_security_group.sg-allow-redis.id]
 
   cluster_mode {
-    num_node_groups         = 1
-    replicas_per_node_group = 0
+    num_node_groups         = lookup(var.num_node_groups, var.env)
+    replicas_per_node_group = lookup(var.replicas_per_node_groups, var.env)
   }
 
   tags = {

--- a/infra/tf-db/main.tf
+++ b/infra/tf-db/main.tf
@@ -82,11 +82,7 @@ resource "aws_elasticache_replication_group" "click_count" {
   port                          = 6379
   parameter_group_name          = lookup(var.parameter_group_names, var.env)
   security_group_ids            = [data.aws_security_group.sg-allow-redis.id]
-
-  cluster_mode {
-    num_node_groups         = lookup(var.num_node_groups, var.env)
-    replicas_per_node_group = lookup(var.replicas_per_node_groups, var.env)
-  }
+  number_cache_clusters         = lookup(var.number_cache_clusters, var.env)
 
   tags = {
     Env         = var.env

--- a/infra/tf-db/variables.tf
+++ b/infra/tf-db/variables.tf
@@ -43,18 +43,10 @@ variable "parameter_group_names" {
   }
 }
 
-variable "num_node_groups" {
+variable "number_cache_clusters" {
   type = map
   default = {
     staging    = 1
     production = 1
-  }
-}
-
-variable "replicas_per_node_groups" {
-  type = map
-  default = {
-    staging    = 0
-    production = 0
   }
 }

--- a/infra/tf-db/variables.tf
+++ b/infra/tf-db/variables.tf
@@ -18,7 +18,6 @@ variable "stack" {
   default = "redis"
 }
 
-
 variable "aws_region" {
   type    = string
   default = "eu-west-3"
@@ -26,4 +25,36 @@ variable "aws_region" {
 
 variable "env" {
   description = "env: staging or production"
+}
+
+variable "node_types" {
+  type = map
+  default = {
+    staging    = "cache.t2.micro"
+    production = "cache.t2.micro"
+  }
+}
+
+variable "parameter_group_names" {
+  type = map
+  default = {
+    staging    = "default.redis6.x"
+    production = "default.redis6.x"
+  }
+}
+
+variable "num_node_groups" {
+  type = map
+  default = {
+    staging    = 1
+    production = 1
+  }
+}
+
+variable "replicas_per_node_groups" {
+  type = map
+  default = {
+    staging    = 0
+    production = 0
+  }
 }


### PR DESCRIPTION
Closes #14 

This allows us to customize a resource per environment. Say we want more
shards in production's elasticache, now we can change the corresponding
variable.